### PR TITLE
Fix CI: Add pixi.toml configuration file

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,18 @@
+[project]
+name = "plot-publisher"
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
+
+[dependencies]
+python = ">=3.9"
+plotly = "*"
+requests = "*"
+numpy = "*"
+pytest = "*"
+pytest-cov = "*"
+pre-commit = "*"
+
+[tasks]
+test = "pytest tests/ --cov=src/plot_publisherpy --cov-report=xml --cov-report=term-missing"
+lint = "pre-commit run --all-files"
+install-dev = "pip install -e ." 


### PR DESCRIPTION
This PR adds the missing pixi.toml configuration file that was causing GitHub Actions workflows to fail. Added pixi.toml with project dependencies and tasks, defines test/lint/install-dev tasks for CI/CD, specifies Python >=3.9 and required dependencies. Verified pixi install and pixi run test work locally with all tests passing.