### PR TITLE
Add function to handle Plotly binary-encoded arrays

### DIFF
--- a/src/plot_publisher/_plot_publisher.py
+++ b/src/plot_publisher/_plot_publisher.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
+import base64
 import json
 import logging
 import re
 import string
 from typing import Dict, List, Optional, Union
 
+import numpy as np
 import requests
 import urllib3
 
@@ -186,6 +188,29 @@ def _is_plotly_html_content(content: str) -> bool:
     return all(plotly_indicators)
 
 
+def _decode_plotly_array(value):
+    """
+    Decode a Plotly array value, handling both plain lists and binary-encoded arrays.
+
+    Plotly may serialize numpy arrays as {'bdata': '<base64>', 'dtype': '<dtype>'}
+    or 2-D arrays as {'bdata': '<base64>', 'dtype': '<dtype>', 'shape': 'rows, cols'}.
+
+    @param value: Either a plain list or a Plotly binary-encoded dict.
+    @return: Plain Python list of values (or list of lists for 2-D arrays).
+    """
+    if isinstance(value, list):
+        return value
+    if isinstance(value, dict) and "bdata" in value and "dtype" in value:
+        raw = base64.b64decode(value["bdata"])
+        arr = np.frombuffer(raw, dtype=value["dtype"])
+        if "shape" in value:
+            shape = tuple(int(s) for s in value["shape"].split(","))
+            arr = arr.reshape(shape)
+            return arr.tolist()
+        return arr.tolist()
+    return list(value) if value else []
+
+
 def plot1d(
     run_number: Union[int, str],
     data_list: Union[List[float], List[List[float]]],
@@ -329,6 +354,10 @@ def extract_plot1d_data(plot_div: str) -> Plot1DDataHint:
     Error bar arrays are always extracted regardless of their ``visible`` flag.
     All values are returned as plain Python lists.
 
+    The original ``x``, ``y``, and ``z`` inputs to :func:`plot_heatmap` may have
+    been plain Python lists or NumPy arrays (including 2-D arrays for ``z``).
+    Regardless of the original type, all returned values are plain Python lists.
+
     @param plot_div: HTML div string produced by :func:`plot1d` with
                     ``publish=False``.
     @return: List of traces, where each trace is ``[x, y]``, ``[x, y, dy]``,
@@ -363,19 +392,19 @@ def extract_plot1d_data(plot_div: str) -> Plot1DDataHint:
         if not isinstance(trace, dict):
             continue
 
-        x = list(trace.get("x", []))
-        y = list(trace.get("y", []))
+        x = _decode_plotly_array(trace.get("x", []))
+        y = _decode_plotly_array(trace.get("y", []))
 
         # Extract error bar arrays regardless of the visible flag
         dy: List = []
         error_y = trace.get("error_y", {})
         if isinstance(error_y, dict) and "array" in error_y:
-            dy = list(error_y["array"])
+            dy = _decode_plotly_array(error_y["array"])
 
         dx: List = []
         error_x = trace.get("error_x", {})
         if isinstance(error_x, dict) and "array" in error_x:
-            dx = list(error_x["array"])
+            dx = _decode_plotly_array(error_x["array"])
 
         if dx:
             result.append([x, y, dy, dx])
@@ -490,6 +519,10 @@ def extract_heatmap_data(plot_div: str) -> HeatmapDataHint:
     Extract data from a Plotly HTML div produced by :func:`plot_heatmap` and
     reconstruct the original ``x``, ``y``, ``z`` arrays.
 
+    The original ``x``, ``y``, and ``z`` inputs to :func:`plot_heatmap` may have
+    been plain Python lists or NumPy arrays (including 2-D arrays for ``z``).
+    Regardless of the original type, all returned values are plain Python lists.
+
     @param plot_div: HTML div string produced by :func:`plot_heatmap` with
                     ``publish=False``.
     @return: ``[x, y, z]`` where each element is a plain Python list
@@ -522,9 +555,9 @@ def extract_heatmap_data(plot_div: str) -> HeatmapDataHint:
     if "z" not in trace:
         raise ValueError("No z data found in trace; the div may not be a heatmap or surface plot")
 
-    x = list(trace.get("x", []))
-    y = list(trace.get("y", []))
-    z = [list(row) for row in trace["z"]]
+    x = _decode_plotly_array(trace.get("x", []))
+    y = _decode_plotly_array(trace.get("y", []))
+    z = _decode_plotly_array(trace["z"])
 
     return [x, y, z]
 
@@ -552,6 +585,10 @@ def extract_data(plot_div: str) -> PlotDataHint:
 
     All arrays are plain Python lists.  Error bar arrays in 1D plots are always returned
     regardless of their ``visible`` flag.
+
+    The original inputs to :func:`plot1d` or :func:`plot_heatmap` may have been
+    plain Python lists or NumPy arrays. Regardless of the original type, all
+    returned values are plain Python lists.
 
     @param plot_div: HTML div string produced by :func:`plot1d` or
                     :func:`plot_heatmap` with ``publish=False``.

--- a/src/plot_publisher/_plot_publisher.py
+++ b/src/plot_publisher/_plot_publisher.py
@@ -354,7 +354,7 @@ def extract_plot1d_data(plot_div: str) -> Plot1DDataHint:
     Error bar arrays are always extracted regardless of their ``visible`` flag.
     All values are returned as plain Python lists.
 
-    The original ``x``, ``y``, and ``z`` inputs to :func:`plot_heatmap` may have
+    The original ``x``, ``y``, and ``z`` inputs to :func:`plot1d` may have
     been plain Python lists or NumPy arrays (including 2-D arrays for ``z``).
     Regardless of the original type, all returned values are plain Python lists.
 

--- a/tests/test_plot_publisher.py
+++ b/tests/test_plot_publisher.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 import requests
 
@@ -776,6 +777,87 @@ class TestExtractPlot1dData:
         rx, ry, rdy, rdx = result[0]
         assert rdx == pytest.approx(dx)
 
+    def test_single_trace_xy_numpy(self):
+        """Round-trip [x, y] with numpy arrays."""
+        x = np.linspace(0.0, 2.0, 4)
+        y = np.array([1.0, 2.0, 4.0, 8.0])
+        div = self._make_div([[x, y]])
+        result = extract_plot1d_data(div)
+        assert len(result) == 1
+        rx, ry = result[0]
+        assert isinstance(rx, list)
+        assert isinstance(ry, list)
+        assert rx == pytest.approx(x.tolist())
+        assert ry == pytest.approx(y.tolist())
+
+    def test_single_trace_with_dy_numpy(self):
+        """Round-trip [x, y, dy] with numpy arrays – Y error bars only."""
+        x = np.linspace(1.0, 3.0, 3)
+        y = np.array([1.0, 4.0, 9.0])
+        dy = np.array([0.1, 0.2, 0.3])
+        div = self._make_div([[x, y, dy]])
+        result = extract_plot1d_data(div)
+        assert len(result) == 1
+        rx, ry, rdy = result[0]
+        assert isinstance(rdy, list)
+        assert rx == pytest.approx(x.tolist())
+        assert ry == pytest.approx(y.tolist())
+        assert rdy == pytest.approx(dy.tolist())
+
+    def test_single_trace_with_dy_dx_numpy(self):
+        """Round-trip [x, y, dy, dx] with numpy arrays – both error bars."""
+        x = np.linspace(1.0, 3.0, 3)
+        y = np.array([1.0, 4.0, 9.0])
+        dy = np.array([0.1, 0.2, 0.3])
+        dx = np.array([0.05, 0.10, 0.15])
+        div = self._make_div([[x, y, dy, dx]])
+        result = extract_plot1d_data(div)
+        assert len(result) == 1
+        rx, ry, rdy, rdx = result[0]
+        assert isinstance(rdx, list)
+        assert rx == pytest.approx(x.tolist())
+        assert ry == pytest.approx(y.tolist())
+        assert rdy == pytest.approx(dy.tolist())
+        assert rdx == pytest.approx(dx.tolist())
+
+    def test_multiple_traces_numpy(self):
+        """Round-trip with two traces using numpy arrays."""
+        x1 = np.linspace(0.0, 1.0, 3)
+        y1 = np.array([0.0, 0.5, 1.0])
+        x2 = np.linspace(10.0, 20.0, 3)
+        y2 = np.array([100.0, 150.0, 200.0])
+        div = self._make_div([[x1, y1], [x2, y2]])
+        result = extract_plot1d_data(div)
+        assert len(result) == 2
+        assert isinstance(result[0][0], list)
+        assert isinstance(result[1][1], list)
+        assert result[0][0] == pytest.approx(x1.tolist())
+        assert result[0][1] == pytest.approx(y1.tolist())
+        assert result[1][0] == pytest.approx(x2.tolist())
+        assert result[1][1] == pytest.approx(y2.tolist())
+
+    def test_multiple_traces_with_errors_numpy(self):
+        """Round-trip with two traces carrying dy and dx as numpy arrays."""
+        x1 = np.linspace(1.0, 2.0, 2)
+        y1 = np.array([3.0, 4.0])
+        dy1 = np.array([0.1, 0.2])
+        dx1 = np.array([0.01, 0.02])
+        x2 = np.linspace(5.0, 6.0, 2)
+        y2 = np.array([7.0, 8.0])
+        dy2 = np.array([0.3, 0.4])
+        dx2 = np.array([0.03, 0.04])
+        div = self._make_div([[x1, y1, dy1, dx1], [x2, y2, dy2, dx2]])
+        result = extract_plot1d_data(div)
+        assert len(result) == 2
+        assert result[0][0] == pytest.approx(x1.tolist())
+        assert result[0][1] == pytest.approx(y1.tolist())
+        assert result[0][2] == pytest.approx(dy1.tolist())
+        assert result[0][3] == pytest.approx(dx1.tolist())
+        assert result[1][0] == pytest.approx(x2.tolist())
+        assert result[1][1] == pytest.approx(y2.tolist())
+        assert result[1][2] == pytest.approx(dy2.tolist())
+        assert result[1][3] == pytest.approx(dx2.tolist())
+
 
 class TestExtractHeatmapData:
     """Test suite for extract_heatmap_data functionality."""
@@ -850,6 +932,46 @@ class TestExtractHeatmapData:
         for row, expected_row in zip(rz, z):
             assert row == pytest.approx(expected_row)
 
+    def test_heatmap_round_trip_all_numpy(self):
+        """Round-trip when x, y, and z are all numpy arrays."""
+        x = np.array([90.0, 2.0, 3])
+        y = np.array([0.0, 1.0, 2])
+        z = np.array([[1.0, 4.0, 9.0], [2.0, 8.0, 18.0]])
+        div = self._make_div(x, y, z)
+        rx, ry, rz = extract_heatmap_data(div)
+        assert isinstance(rx, list)
+        assert isinstance(ry, list)
+        assert isinstance(rz, list)
+        assert rx == pytest.approx(x.tolist())
+        assert ry == pytest.approx(y.tolist())
+        for row, expected_row in zip(rz, z.tolist()):
+            assert row == pytest.approx(expected_row)
+
+    def test_heatmap_round_trip_numpy_linspace(self):
+        """Round-trip with numpy linspace arrays for x, y, and a computed z grid."""
+        x = np.linspace(0.0, 1.0, 5)
+        y = np.linspace(-1.0, 1.0, 4)
+        z = np.outer(y, x)  # 4x5 grid
+        div = self._make_div(x, y, z)
+        rx, ry, rz = extract_heatmap_data(div)
+        assert rx == pytest.approx(x.tolist())
+        assert ry == pytest.approx(y.tolist())
+        assert len(rz) == len(z)
+        for row, expected_row in zip(rz, z.tolist()):
+            assert row == pytest.approx(expected_row)
+
+    def test_heatmap_round_trip_mixed_numpy_lists(self):
+        """Round-trip with numpy arrays for x and y but plain lists for z."""
+        x = np.linspace(1.0, 3.0, 3)
+        y = np.linspace(4.0, 5.0, 2)
+        z = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]  # plain list
+        div = self._make_div(x, y, z)
+        rx, ry, rz = extract_heatmap_data(div)
+        assert rx == pytest.approx(x.tolist())
+        assert ry == pytest.approx(y.tolist())
+        for row, expected_row in zip(rz, z):
+            assert row == pytest.approx(expected_row)
+
 
 class TestExtractData:
     """Test suite for the extract_data dispatcher function."""
@@ -873,59 +995,88 @@ class TestExtractData:
         with pytest.raises(ValueError, match="Failed to parse Plotly JSON data"):
             extract_data(bad_div)
 
-    def test_dispatches_to_plot1d_xy(self):
+    @pytest.mark.parametrize("use_numpy", [False, True])
+    def test_dispatches_to_plot1d_xy(self, use_numpy):
         """Delegates to extract_plot1d_data for a basic [x, y] plot."""
         x, y = [1.0, 2.0, 3.0], [4.0, 5.0, 6.0]
+        if use_numpy:
+            x, y = np.array(x), np.array(y)
         div = plot1d(run_number=1, data_list=[[x, y]], publish=False)
         result = extract_data(div)
         assert len(result) == 1
-        assert result[0][0] == pytest.approx(x)
-        assert result[0][1] == pytest.approx(y)
+        assert result[0][0] == pytest.approx(list(x))
+        assert result[0][1] == pytest.approx(list(y))
+        if use_numpy:
+            assert isinstance(result[0][0], list)
+            assert isinstance(result[0][1], list)
 
-    def test_dispatches_to_plot1d_with_errors(self):
+    @pytest.mark.parametrize("use_numpy", [False, True])
+    def test_dispatches_to_plot1d_with_errors(self, use_numpy):
         """Delegates to extract_plot1d_data for a plot with dy and dx."""
         x, y = [1.0, 2.0, 3.0], [1.0, 4.0, 9.0]
         dy, dx = [0.1, 0.2, 0.3], [0.05, 0.10, 0.15]
+        if use_numpy:
+            x, y, dy, dx = np.array(x), np.array(y), np.array(dy), np.array(dx)
         div = plot1d(run_number=1, data_list=[[x, y, dy, dx]], publish=False)
         result = extract_data(div)
         assert len(result) == 1
         rx, ry, rdy, rdx = result[0]
-        assert rx == pytest.approx(x)
-        assert ry == pytest.approx(y)
-        assert rdy == pytest.approx(dy)
-        assert rdx == pytest.approx(dx)
+        assert rx == pytest.approx(list(x))
+        assert ry == pytest.approx(list(y))
+        assert rdy == pytest.approx(list(dy))
+        assert rdx == pytest.approx(list(dx))
+        if use_numpy:
+            assert all(isinstance(v, list) for v in (rx, ry, rdy, rdx))
 
-    def test_dispatches_to_plot1d_multiple_traces(self):
+    @pytest.mark.parametrize("use_numpy", [False, True])
+    def test_dispatches_to_plot1d_multiple_traces(self, use_numpy):
         """Delegates to extract_plot1d_data for multiple traces."""
         x1, y1 = [1.0, 2.0], [3.0, 4.0]
         x2, y2 = [5.0, 6.0], [7.0, 8.0]
+        if use_numpy:
+            x1, y1, x2, y2 = np.array(x1), np.array(y1), np.array(x2), np.array(y2)
         div = plot1d(run_number=1, data_list=[[x1, y1], [x2, y2]], publish=False)
         result = extract_data(div)
         assert len(result) == 2
-        assert result[0][0] == pytest.approx(x1)
-        assert result[1][0] == pytest.approx(x2)
+        assert result[0][0] == pytest.approx(list(x1))
+        assert result[1][0] == pytest.approx(list(x2))
+        if use_numpy:
+            assert isinstance(result[0][0], list)
+            assert isinstance(result[1][0], list)
 
-    def test_dispatches_to_heatmap(self):
+    @pytest.mark.parametrize("use_numpy", [False, True])
+    def test_dispatches_to_heatmap(self, use_numpy):
         """Delegates to extract_heatmap_data for a heatmap plot."""
         x = [1.0, 2.0, 3.0]
         y = [4.0, 5.0]
         z = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]
+        if use_numpy:
+            x, y, z = np.array(x), np.array(y), np.array(z)
         div = plot_heatmap(run_number=1, x=x, y=y, z=z, publish=False)
         rx, ry, rz = extract_data(div)
-        assert rx == pytest.approx(x)
-        assert ry == pytest.approx(y)
-        for row, expected_row in zip(rz, z):
+        z_list = z.tolist() if use_numpy else z
+        assert rx == pytest.approx(list(x))
+        assert ry == pytest.approx(list(y))
+        for row, expected_row in zip(rz, z_list):
             assert row == pytest.approx(expected_row)
+        if use_numpy:
+            assert all(isinstance(v, list) for v in (rx, ry, rz))
 
-    def test_dispatches_to_surface(self):
+    @pytest.mark.parametrize("use_numpy", [False, True])
+    def test_dispatches_to_surface(self, use_numpy):
         """Delegates to extract_heatmap_data for a surface plot."""
         x = [0.0, 1.0, 2.0]
         y = [0.0, 1.0]
         z = [[1.0, 4.0, 9.0], [2.0, 8.0, 18.0]]
+        if use_numpy:
+            x, y, z = np.array(x), np.array(y), np.array(z)
         div = plot_heatmap(run_number=1, x=x, y=y, z=z, surface=True, publish=False)
         rx, ry, rz = extract_data(div)
-        assert rx == pytest.approx(x)
-        assert ry == pytest.approx(y)
-        for row, expected_row in zip(rz, z):
+        z_list = z.tolist() if use_numpy else z
+        assert rx == pytest.approx(list(x))
+        assert ry == pytest.approx(list(y))
+        for row, expected_row in zip(rz, z_list):
             assert row == pytest.approx(expected_row)
+        if use_numpy:
+            assert all(isinstance(v, list) for v in (rx, ry, rz))
 


### PR DESCRIPTION
# Description of the changes:

Improves plot_publisher’s data-extraction helpers to handle Plotly’s binary-encoded array representation (commonly produced when inputs are NumPy arrays)

Changes:

- Add _decode_plotly_array to decode Plotly {bdata, dtype, (shape)} array payloads into Python lists.
- Update extract_plot1d_data / extract_heatmap_data to use _decode_plotly_array and standardize outputs to plain lists.
- Expand tests to cover NumPy inputs for 1D plots, heatmaps, and the extract_data dispatcher.

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
